### PR TITLE
Implement file loading functionality

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,11 +9,13 @@
  * `./src/main.js` using webpack. This gives us some performance wins.
  */
 import path from 'path';
-import { app, BrowserWindow, shell, ipcMain } from 'electron';
+import { app, BrowserWindow, shell, ipcMain, dialog } from 'electron';
 import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import MenuBuilder from './menu';
 import { resolveHtmlPath } from './util';
+
+const fs = require('fs');
 
 import * as Modules from './modules';
 
@@ -162,6 +164,41 @@ app
     Object.values(Modules.ALL_MODULES).forEach(moduleName => {
       ipcMain.on(moduleName, (_event, payload) => {
         moduleWindows[moduleName].webContents.send(moduleName, payload);
+      });
+    });
+
+    ipcMain.on('file', (_event, tag) => {
+      dialog.showOpenDialog({
+        properties: ['openFile']
+      })
+      .then((response) => {
+        if(!response.canceled) {
+          _event.sender.send('file', response.filePaths[0]);
+
+          fs.readFile(response.filePaths[0], 'utf8', (err, data) => {
+            if(err) {
+              _event.sender.send('file', {
+                tag: tag,
+                status: 'error',
+                payload: err
+              });
+
+              return;
+            }
+
+            _event.sender.send('file', {
+              tag: tag,
+              status: 'success',
+              payload: data
+            });
+          });
+        } else {
+          _event.sender.send('file', {
+            tag: tag,
+            status: 'error',
+            payload: 'cancelled'
+          });
+        }
       });
     });
   })

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -10,24 +10,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
   subscribeTrainModelMessage:       (callback) => ipcRenderer.on(Modules.TRAIN_MODEL, callback),
   subscribeTrainControllerMessage:  (callback) => ipcRenderer.on(Modules.TRAIN_CONTROLLER, callback),
 
+  subscribeFileMessage: (callback) => ipcRenderer.on('file', callback),
+
   // These will be called by the electron:renderer process for this module
   // send*Message:    Asynchronously send a message (no response expected)
   // receive*Message: Asynchronously send a message (and expect a response)
   sendCTCMessage:                 (payload) => ipcRenderer.send(Modules.CTC_OFFICE, payload),
-  requestCTCMessage:              (payload) => ipcRenderer.invoke(Modules.CTC_OFFICE, payload),
-
   sendTrackControllerMessage:     (payload) => ipcRenderer.send(Modules.TRACK_CONTROLLER, payload),
-  requestTrackControllerMessage:  (payload) => ipcRenderer.invoke(Modules.TRACK_CONTROLLER, payload),
-
   sendTrackModelMessage:          (payload) => ipcRenderer.send(Modules.TRACK_MODEL, payload),
-  requestTrackModelMessage:       (payload) => ipcRenderer.invoke(Modules.TRACK_MODEL, payload),
-
   sendTrainModelMessage:          (payload) => ipcRenderer.send(Modules.TRAIN_MODEL, payload),
-  requestTrainModelMessage:       (payload) => ipcRenderer.invoke(Modules.TRAIN_MODEL, payload),
+  sendTrainControllerSWMessage:   (payload) => ipcRenderer.send(Modules.TRAIN_CONTROLLER_SW, payload),
+  sendTrainControllerHWMessage:   (payload) => ipcRenderer.send(Modules.TRAIN_CONTROLLER_SW, payload),
 
-  sendTrainControllerSWMessage:     (payload) => ipcRenderer.send(Modules.TRAIN_CONTROLLER_SW, payload),
-  requestTrainControllerSWMessage:  (payload) => ipcRenderer.invoke(Modules.TRAIN_CONTROLLER_SW, payload),
-
-  sendTrainControllerHWMessage:     (payload) => ipcRenderer.send(Modules.TRAIN_CONTROLLER_SW, payload),
-  requestTrainControllerHWMessage:  (payload) => ipcRenderer.invoke(Modules.TRAIN_CONTROLLER_SW, payload),
+  openFileDialog: (tag) => ipcRenderer.send('file', tag)
 });

--- a/src/modules/CTCOffice.jsx
+++ b/src/modules/CTCOffice.jsx
@@ -69,9 +69,15 @@ class CTCOffice extends React.Component {
           // TODO: message validation
           this.updateBlockOccupancy(payload.line, payload.block_id, payload.value);
           break;
+        case 'timing':
+          console.log(Date.now() - payload.value);
         default:
           console.warn('Unknown payload type received: ', payload.type);
       }
+    });
+
+    window.electronAPI.subscribeFileMessage( (_event, payload) => {
+      console.log(payload);
     });
 
     this.state = {


### PR DESCRIPTION
This allows us to load files. Basic idea is you send a request to open a file dialogue, then you'll get back the file contents (or error message) as an asynchronous response.

## Receiving files
Very similar to receiving your module's IPC messages. In your constructor function, add
```javascript
    window.electronAPI.subscribeFileMessage( (_event, payload) => {
      console.log(payload);
    });
```
The payload object will have three attributes (accessible via e.g. `payload.tag`, `payload.status`, `payload.payload`, etc):
 - **tag** - a tag that you specified when calling this file open dialogue for you to help discern multiple possible file messages
 - **status** - either 'error' or 'success', indicates what's in the payload
 - **payload** - If success status, `payload` will have file contents, and on error status it will contain the error message.
 
 ## Requesting file open dialogue
Simply call:
```javascript
window.electronAPI.openFileDialog('schedule')
```
From anywhere in your module. The parameter there is the `tag` attribute. Totally optional, you might not need it, but it can be used to identify a sequence of `file` messages (it's like a sequence number in TCP).