### PR TITLE
Add Timer module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "dependencies": {
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
+        "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.6",
         "@picocss/pico": "^1.5.2",
         "cytoscape": "^3.21.2",
@@ -1622,6 +1623,31 @@
         "@types/react": "^17.0.0 || ^18.0.0",
         "react": "^17.0.0 || ^18.0.0",
         "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
+      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "dependencies": {
+        "@babel/runtime": "^7.17.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -18334,6 +18360,14 @@
         "clsx": "^1.2.0",
         "prop-types": "^15.8.1",
         "react-is": "^17.0.2"
+      }
+    },
+    "@mui/icons-material": {
+      "version": "5.8.4",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.8.4.tgz",
+      "integrity": "sha512-9Z/vyj2szvEhGWDvb+gG875bOGm8b8rlHBKOD1+nA3PcgC3fV6W1AU6pfOorPeBfH2X4mb9Boe97vHvaSndQvA==",
+      "requires": {
+        "@babel/runtime": "^7.17.2"
       }
     },
     "@mui/material": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.6",
     "@picocss/pico": "^1.5.2",
     "cytoscape": "^3.21.2",

--- a/src/main/Timer.ts
+++ b/src/main/Timer.ts
@@ -1,0 +1,83 @@
+class Timer {
+  /** Callback to call when this timer ticks */
+  private onClock_cb: (timestamp: number) => void;
+
+  /** Number of ms since midnight */
+  private _timestamp: number = 0;
+
+  /** If timer is in paused state or not */
+  private _paused: boolean = true;
+
+  /**
+  * Multiplier for emitting clock signals faster
+  * 1 is realtime, 2 is 2x realtime
+  */
+  private _timeScalar: number = 1;
+
+  /** Object returned by setInterval */
+  private _clockTimer: any = undefined;
+
+  /** Number of ms that a clock signal represents */
+  public readonly timestep: number;
+
+  private computeInterval(): number {
+    return this.timestep / this._timeScalar;
+  }
+
+  /** Called when timer needs to clock */
+  private clock(): void {
+    // Increment internal time and call cb
+    // 86400000 == # ms in a day
+    this._timestamp = (this._timestamp + this.timestep) % 86400000;
+    this.onClock_cb(this._timestamp);
+  }
+
+  private reinitializeTimer(): void {
+    // TODO: Logic for remaining time? node api doesn't have this unfortunately so needs estimated
+
+    // Clear clock timer if one exists
+    if(this._clockTimer)
+      clearInterval(this._clockTimer);
+
+    if(!this._paused) {
+      // Set clock timer back up again with new interval
+      this._clockTimer = setInterval(() => {
+        this.clock();
+      }, this.computeInterval());
+    }
+  }
+
+  constructor(timestep_ms: number, initial_time?: number) {
+    this.timestep = timestep_ms;
+
+    if(initial_time)
+      this._timestamp = initial_time;
+  }
+
+  public onClock(onClock: (timestamp: number) => void): void {
+    this.onClock_cb = onClock;
+  }
+
+  public setTimeScalar(scalar: number): void {
+    // Nothing needs done if no change
+    if(scalar === this._timeScalar)
+      return;
+
+    this._timeScalar = scalar;
+    this.reinitializeTimer();
+  }
+
+  public pause(doPause: bool): void {
+    if(this._paused === doPause)
+      return;
+
+    this._paused = doPause;
+    this.reinitializeTimer();
+  }
+
+  public start(): void {
+    this.reinitializeTimer();
+  }
+};
+
+export default Timer;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -187,8 +187,8 @@ app
       console.log('timer::pause', payload)
     });
 
-    ipcMain.on('timer::fast-forward', (_event, payload) => {
-      console.log('timer::fast-forward', payload)
+    ipcMain.on('timer::time-multiplier', (_event, payload) => {
+      console.log('timer::time-multiplier', payload)
     });
   })
   .catch(console.log);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -55,11 +55,12 @@ const installExtensions = async () => {
 
 const activeModules = [
   'CTCOffice',
-  'TrackController',
+  //'TrackController',
   // 'TrackModel',
   // 'TrainModel',
   // 'TrainControllerHW',
-  'TrainControllerSW',
+  //'TrainControllerSW',
+  'Timer',
 ];
 
 const createWindow = async (moduleName: string) => {
@@ -75,17 +76,34 @@ const createWindow = async (moduleName: string) => {
     return path.join(RESOURCES_PATH, ...paths);
   };
 
-  let moduleWindow = new BrowserWindow({
-    show: false,
-    width: 1024,
-    height: 728,
-    icon: getAssetPath('icon.png'),
-    webPreferences: {
-      preload: app.isPackaged
-        ? path.join(__dirname, 'preload.js')
-        : path.join(__dirname, '../../.erb/dll/preload.js'),
-    },
-  });
+  let moduleWindow;
+  if(moduleName === Modules.TIMER) {
+    moduleWindow = new BrowserWindow({
+      show: false,
+      width: 350,
+      height: 250,
+      icon: getAssetPath('icon.png'),
+      webPreferences: {
+        preload: app.isPackaged
+          ? path.join(__dirname, 'preload.js')
+          : path.join(__dirname, '../../.erb/dll/preload.js'),
+      },
+    });
+  } else {
+    moduleWindow = new BrowserWindow({
+      show: false,
+      width: 1024,
+      height: 728,
+      icon: getAssetPath('icon.png'),
+      webPreferences: {
+        preload: app.isPackaged
+          ? path.join(__dirname, 'preload.js')
+          : path.join(__dirname, '../../.erb/dll/preload.js'),
+      },
+    });
+  }
+
+
   moduleWindows[moduleName] = moduleWindow;
 
   moduleWindow.loadURL(`${resolveHtmlPath('index.html')}#${moduleName}`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -182,5 +182,13 @@ app
         moduleWindows[moduleName].webContents.send(moduleName, payload);
       });
     });
+
+    ipcMain.on('timer::pause', (_event, payload) => {
+      console.log('timer::pause', payload)
+    });
+
+    ipcMain.on('timer::fast-forward', (_event, payload) => {
+      console.log('timer::fast-forward', payload)
+    });
   })
   .catch(console.log);

--- a/src/main/modules.ts
+++ b/src/main/modules.ts
@@ -4,6 +4,7 @@ export const TRACK_MODEL          = 'TrackModel';
 export const TRAIN_MODEL          = 'TrainModel';
 export const TRAIN_CONTROLLER_SW  = 'TrainControllerSW';
 export const TRAIN_CONTROLLER_HW  = 'TrainControllerHW';
+export const TIMER                = 'Timer';
 
 export const ALL_MODULES = {
   CTC_OFFICE,
@@ -12,6 +13,7 @@ export const ALL_MODULES = {
   TRAIN_MODEL,
   TRAIN_CONTROLLER_SW,
   TRAIN_CONTROLLER_HW,
+  TIMER,
 };
 
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -9,6 +9,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   subscribeTrackModelMessage:       (callback) => ipcRenderer.on(Modules.TRACK_MODEL, callback),
   subscribeTrainModelMessage:       (callback) => ipcRenderer.on(Modules.TRAIN_MODEL, callback),
   subscribeTrainControllerMessage:  (callback) => ipcRenderer.on(Modules.TRAIN_CONTROLLER, callback),
+  subscribeTimerMessage:            (callback) => ipcRenderer.on(Modules.TIMER, callback),
 
   // These will be called by the electron:renderer process for this module
   // send*Message:    Asynchronously send a message (no response expected)

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -33,5 +33,5 @@ contextBridge.exposeInMainWorld('electronAPI', {
   requestTrainControllerHWMessage:  (payload) => ipcRenderer.invoke(Modules.TRAIN_CONTROLLER_SW, payload),
 
   sendTimePause:          (doPause) => ipcRenderer.send('timer::pause', doPause),
-  sendTimeFastForward:    (doFastForward) => ipcRenderer.send('timer::fast-forward', doFastForward),
+  sendTimeFastForward:    (timeScalar) => ipcRenderer.send('timer::time-multiplier', timeScalar),
 });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -31,4 +31,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   sendTrainControllerHWMessage:     (payload) => ipcRenderer.send(Modules.TRAIN_CONTROLLER_SW, payload),
   requestTrainControllerHWMessage:  (payload) => ipcRenderer.invoke(Modules.TRAIN_CONTROLLER_SW, payload),
+
+  sendTimePause:          (doPause) => ipcRenderer.send('timer::pause', doPause),
+  sendTimeFastForward:    (doFastForward) => ipcRenderer.send('timer::fast-forward', doFastForward),
 });

--- a/src/modules/Timer.css
+++ b/src/modules/Timer.css
@@ -1,0 +1,10 @@
+#main {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0;
+}
+
+#main > * {
+  width: 100%;
+}

--- a/src/modules/Timer.css
+++ b/src/modules/Timer.css
@@ -3,8 +3,15 @@
   flex-direction: column;
   flex-wrap: nowrap;
   gap: 0;
+  text-align: center;
 }
 
 #main > * {
   width: 100%;
+}
+
+#timer-button-group {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
 }

--- a/src/modules/Timer.jsx
+++ b/src/modules/Timer.jsx
@@ -10,7 +10,11 @@ import {
   FormControlLabel,
   Box,
   Typography,
+  IconButton
 } from '@mui/material';
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import FastForwardIcon from '@mui/icons-material/FastForward';
 import InputLabel from '@mui/material/InputLabel';
 import MenuItem from '@mui/material/MenuItem';
 import { styled } from '@mui/material/styles';
@@ -31,17 +35,81 @@ class Timer extends React.Component {
   constructor(props) {
     super(props);
 
-    this.state = {};
+    window.electronAPI.subscribeTimerMessage( (_event, payload) => {
+      switch(payload.type) {
+        case 'sync':
+          this.timestamp = payload.value;
+          this.setState({
+            current_time: this.formatTime(this.timestamp),
+          });
+          break;
+        case 'time passed':
+          this.timestamp += payload.value;
+          this.setState({
+            current_time: this.formatTime(this.timestamp),
+          });
+          break;
+        default:
+          console.warn(`Unknown payload type of ${payload.type}`);
+      }
+    });
+
+    // ms since midnight
+    this.timestamp = 8 * 60 * 60 * 1000; // 08:00
+
+    this.state = {
+      current_time: this.formatTime(this.timestamp),
+      isPaused: false,
+      isFastForward: false,
+    };
+  }
+
+  formatTime(n_ms_midnight) {
+    // TODO
+    return '08:00';
   }
 
   render() {
+    const { isPaused, isFastForward, current_time } = this.state;
+
     return (
-      <div id="main">
-        <p>00:00</p>
-        <div id="timer-button-group">
-          Buttons
+      <ThemeProvider theme={darkTheme}>
+        <div id="main">
+          <Typography variant="h4">Current Time:</Typography>
+          <Typography variant="h3">{this.formatTime(current_time)}</Typography>
+          <div id="timer-button-group">
+            {
+              isPaused ?
+                <IconButton color="default" aria-label="pause" component="span" size="large"
+                  onClick={() => { this.setState({isPaused: false}) }}
+                >
+                  <PlayArrowIcon/>
+                </IconButton>
+              :
+                <IconButton color="default" aria-label="pause" component="span" size="large"
+                  onClick={() => { this.setState({isPaused: true}) }}
+                >
+                  <PauseIcon/>
+                </IconButton>
+            }
+            {
+              isFastForward ?
+                <IconButton color="default" aria-label="pause" component="span" color="primary" size="large"
+                  onClick={() => { this.setState({isFastForward: false}) }}
+                >
+                  <FastForwardIcon/>
+                </IconButton>
+              :
+                <IconButton color="default" aria-label="pause" component="span" size="large"
+                  onClick={() => { this.setState({isFastForward: true}) }}
+                >
+                  <FastForwardIcon/>
+                </IconButton>
+
+            }
+          </div>
         </div>
-      </div>
+      </ThemeProvider>
     );
   }
 };

--- a/src/modules/Timer.jsx
+++ b/src/modules/Timer.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import {
+  Button,
+  ThemeProvider,
+  createTheme,
+  Modal,
+  TextField,
+  Switch,
+  FormGroup,
+  FormControlLabel,
+  Box,
+  Typography,
+} from '@mui/material';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import { styled } from '@mui/material/styles';
+
+import './Timer.css';
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+});
+
+const Input = styled('input')({
+  display: 'none',
+});
+
+class Timer extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div id="main">
+        <p>00:00</p>
+        <div id="timer-button-group">
+          Buttons
+        </div>
+      </div>
+    );
+  }
+};
+
+export default Timer;

--- a/src/modules/Timer.jsx
+++ b/src/modules/Timer.jsx
@@ -36,22 +36,12 @@ class Timer extends React.Component {
     super(props);
 
     window.electronAPI.subscribeTimerMessage( (_event, payload) => {
-      switch(payload.type) {
-        case 'sync':
-          this.timestamp = payload.value;
-          this.setState({
-            current_time: this.formatTime(this.timestamp),
-          });
-          break;
-        case 'time passed':
-          this.timestamp += payload.value;
-          this.setState({
-            current_time: this.formatTime(this.timestamp),
-          });
-          break;
-        default:
-          console.warn(`Unknown payload type of ${payload.type}`);
-      }
+      const { timestamp } = payload;
+      this.timestamp = timestamp;
+
+      this.setState({
+        current_time: this.formatTime(this.timestamp),
+      });
     });
 
     // ms since midnight

--- a/src/modules/Timer.jsx
+++ b/src/modules/Timer.jsx
@@ -82,7 +82,9 @@ class Timer extends React.Component {
       isFastForward: newFastForwardState,
     });
 
-    window.electronAPI.sendTimeFastForward(newFastForwardState);
+    const timeScalar = (newFastForwardState ? 10.0 : 1.0);
+
+    window.electronAPI.sendTimeFastForward(timeScalar);
   }
 
   handlePausePlayPress() {

--- a/src/modules/Timer.jsx
+++ b/src/modules/Timer.jsx
@@ -55,7 +55,7 @@ class Timer extends React.Component {
     });
 
     // ms since midnight
-    this.timestamp = 8 * 60 * 60 * 1000; // 08:00
+    this.timestamp = 8 * 60 * 60 * 1000 + 1000; // 08:00
 
     this.state = {
       current_time: this.formatTime(this.timestamp),
@@ -65,8 +65,15 @@ class Timer extends React.Component {
   }
 
   formatTime(n_ms_midnight) {
-    // TODO
-    return '08:00';
+    console.log('formatTime', n_ms_midnight);
+    const d = new Date(2000, 0, 1, 0, 0, 0, n_ms_midnight)
+
+    const HH = d.getHours().toString().padStart(2, '0');
+    const MM = d.getMinutes().toString().padStart(2, '0');
+    const SS = d.getSeconds().toString().padStart(2, '0');
+
+    console.log(HH, MM);
+    return `${HH}:${MM}:${SS}`;
   }
 
   render() {
@@ -76,7 +83,7 @@ class Timer extends React.Component {
       <ThemeProvider theme={darkTheme}>
         <div id="main">
           <Typography variant="h4">Current Time:</Typography>
-          <Typography variant="h3">{this.formatTime(current_time)}</Typography>
+          <Typography variant="h3">{current_time}</Typography>
           <div id="timer-button-group">
             {
               isPaused ?

--- a/src/modules/Timer.jsx
+++ b/src/modules/Timer.jsx
@@ -59,21 +59,41 @@ class Timer extends React.Component {
 
     this.state = {
       current_time: this.formatTime(this.timestamp),
-      isPaused: false,
+      isPaused: true,
       isFastForward: false,
     };
   }
 
   formatTime(n_ms_midnight) {
-    console.log('formatTime', n_ms_midnight);
     const d = new Date(2000, 0, 1, 0, 0, 0, n_ms_midnight)
 
     const HH = d.getHours().toString().padStart(2, '0');
     const MM = d.getMinutes().toString().padStart(2, '0');
     const SS = d.getSeconds().toString().padStart(2, '0');
 
-    console.log(HH, MM);
     return `${HH}:${MM}:${SS}`;
+  }
+
+  handleFastForwardPress() {
+    const { isFastForward } = this.state;
+    const newFastForwardState = !isFastForward;
+
+    this.setState({
+      isFastForward: newFastForwardState,
+    });
+
+    window.electronAPI.sendTimeFastForward(newFastForwardState);
+  }
+
+  handlePausePlayPress() {
+    const { isPaused } = this.state;
+    const newPauseState = !isPaused;
+
+    this.setState({
+      isPaused: newPauseState,
+    });
+
+    window.electronAPI.sendTimePause(newPauseState);
   }
 
   render() {
@@ -85,35 +105,26 @@ class Timer extends React.Component {
           <Typography variant="h4">Current Time:</Typography>
           <Typography variant="h3">{current_time}</Typography>
           <div id="timer-button-group">
-            {
-              isPaused ?
-                <IconButton color="default" aria-label="pause" component="span" size="large"
-                  onClick={() => { this.setState({isPaused: false}) }}
-                >
+            <IconButton color="default" aria-label="pause" component="span" size="large"
+              onClick={() => { this.handlePausePlayPress()}}
+            >
+              {
+                isPaused ?
                   <PlayArrowIcon/>
-                </IconButton>
-              :
-                <IconButton color="default" aria-label="pause" component="span" size="large"
-                  onClick={() => { this.setState({isPaused: true}) }}
-                >
+                :
                   <PauseIcon/>
-                </IconButton>
-            }
-            {
-              isFastForward ?
-                <IconButton color="default" aria-label="pause" component="span" color="primary" size="large"
-                  onClick={() => { this.setState({isFastForward: false}) }}
-                >
-                  <FastForwardIcon/>
-                </IconButton>
-              :
-                <IconButton color="default" aria-label="pause" component="span" size="large"
-                  onClick={() => { this.setState({isFastForward: true}) }}
-                >
-                  <FastForwardIcon/>
-                </IconButton>
-
-            }
+              }
+            </IconButton>
+            <IconButton
+              color="default"
+              aria-label="pause"
+              component="span"
+              color={isFastForward ? "primary" : "default"}
+              size="large"
+              onClick={() => { this.handleFastForwardPress() }}
+            >
+              <FastForwardIcon/>
+            </IconButton>
           </div>
         </div>
       </ThemeProvider>

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -7,6 +7,7 @@ import TrackModel from '../modules/TrackModel';
 import TrainModel from '../modules/TrainModel';
 import TrainControllerHW from '../modules/TrainControllerHW';
 import TrainControllerSW from '../modules/TrainControllerSW';
+import Timer from '../modules/Timer';
 
 const Main = () => {
   const activeModule = window.location.hash.slice(1);
@@ -31,6 +32,9 @@ const Main = () => {
       break;
     case 'TrainControllerHW':
       moduleToRender = (<TrainControllerHW/>);
+      break;
+    case 'Timer':
+      moduleToRender = (<Timer/>);
       break;
     default:
       moduleToRender = (<p>Invalid module render selected!</p>);


### PR DESCRIPTION
This adds in another module that acts as the world clock or timer. The way it works is that it simply sends the current timestamp to every module. We can change this if design needs require it, but this timer would still be a good starting point for that. By comparing the previous timestamp with the new current one, you could e.g. advance physics by the amount of milliseconds between the two. Timestamp deltas for now are fixed, so realistically you'd only need to compare previous vs. current once to get the delay between timestamps.

# Receiving Timestamps
[An active example of this seen in the timer controller React module](https://github.com/ctrlaltf2/trains/blob/2ff4812e0da1639d3c86fdd5b1925aaa84ebd7fa/src/modules/Timer.jsx#L38) is:
```javascript
window.electronAPI.subscribeTimerMessage( (_event, payload) => {
  const { timestamp } = payload;
  this.timestamp = timestamp;

  this.setState({
    current_time: this.formatTime(this.timestamp),
  });
});
```
Like with [file loading](https://github.com/ctrlaltf2/trains/pull/15), you need to put this in your React component's `constructor`. The function you throw into `subscribeTimerMessage` runs on every timer message. Inside the payload object, for now, is just a timestamp. However, as design needs require it, this may change.

